### PR TITLE
bubblejail: fix build and address an rpmlint warning

### DIFF
--- a/bubblejail/bubblejail.spec
+++ b/bubblejail/bubblejail.spec
@@ -56,7 +56,7 @@ Bubblejail is a bubblewrap-based alternative to Firejail.
 %_datadir/bash-completion/completions/bubblejail
 %_datadir/bubblejail
 %_datadir/fish/vendor_completions.d/bubblejail.fish
-%_datadir/icons/hicolor/48x48/apps/bubblejail-config.png
+%_datadir/icons/hicolor/128x128/apps/bubblejail-config.png
 %_datadir/icons/hicolor/scalable/apps/bubblejail-config.svg
 %_mandir/man1/bubblejail.1.gz
 %_mandir/man5/bubblejail.services.5.gz

--- a/bubblejail/bubblejail.spec
+++ b/bubblejail/bubblejail.spec
@@ -1,6 +1,6 @@
 Name:           bubblejail
 Version:        0.10.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bubblewrap based sandboxing for desktop applications
 
 License:        GPL-3.0-or-later
@@ -63,6 +63,10 @@ Bubblejail is a bubblewrap-based alternative to Firejail.
 
 
 %changelog
+* Tue Jan 06 2026 wisp3rwind - 0.10.1-2
+- Fix install after igo95862/bubblejail#156
+- migrated to SPDX license
+
 * Sun Nov 02 2025 rusty-snake - 0.10.1-1
 - Update to 0.10.1
 

--- a/bubblejail/bubblejail.spec
+++ b/bubblejail/bubblejail.spec
@@ -3,7 +3,7 @@ Version:        0.10.1
 Release:        1%{?dist}
 Summary:        Bubblewrap based sandboxing for desktop applications
 
-License:        GPLv3+
+License:        GPL-3.0-or-later
 URL:            https://github.com/igo95862/bubblejail
 Source0:        %{url}/releases/download/%{version}/bubblejail-%{version}.tar.xz
 


### PR DESCRIPTION
bubblejail increased the icon size in https://github.com/igo95862/bubblejail/commit/bd82670da2b89fa217e0c1e309d0defcfb66f8af, leading to a build failure. This adapts the spec to the new icon path.

Additionally, it addresses one of rpmlint's warnings (incorrect license identifier), which is particularly annoying because it results in rpmlint printing a rather long list of valid license identifiers. (Cf. https://github.com/igo95862/bubblejail/blob/master/LICENSES/GPL-3.0-or-later.txt, i.e. `GPL-3.0-or-later` is correct.)